### PR TITLE
Fix branch reference in tag-release workflow to use input parameter

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: RoboFinSystems/robosystems-mcp-client
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.branch_ref }}
           token: ${{ secrets.ACTIONS_TOKEN }}
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary of Changes
This PR fixes the tag-release GitHub workflow to properly use the input parameter for branch reference instead of relying on the GitHub ref context. This ensures the workflow operates on the correct branch when triggered with specific branch inputs.

## Technical Details
- **File Modified**: `.github/workflows/tag-release.yml`
- **Change Type**: Single line parameter reference update
- **Impact**: Workflow will now respect branch input parameters correctly

## Key Improvements
- ✅ Workflow now uses explicit input parameter for branch targeting
- ✅ Eliminates potential issues with incorrect branch reference resolution
- ✅ Improves workflow reliability when triggered programmatically or manually

## Breaking Changes
None - This is a workflow configuration fix that doesn't affect application functionality.

## Testing Notes for Reviewers
- [ ] Verify the workflow file syntax is correct
- [ ] Confirm the input parameter name matches the workflow's input definition
- [ ] Test the workflow manually if possible to ensure it targets the correct branch
- [ ] Check that this change doesn't break existing automated triggers

## Browser Compatibility Considerations
Not applicable - This change only affects CI/CD workflow infrastructure and has no impact on browser compatibility or frontend functionality.

## Additional Notes
This is a targeted fix for the deployment pipeline that should improve the reliability of our release process without affecting the application's runtime behavior.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

**Branch Info:**
- Source: `bugfix/gh-ref`
- Target: `main`
- Type: bugfix

Co-Authored-By: Claude <noreply@anthropic.com>