### PR TITLE
chore(githooks): skip hooks in CI environments

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Skip in CI: dedicated jobs run these checks and branch protection is enforced
+# server-side. These hooks are a local-only safety net.
+if [ -n "${CI:-}" ]; then exit 0; fi
+
 # Run checks individually so a failure stops early and is clearly attributed.
 # Use check-only variants (no --write / --fix) — auto-fixing mid-commit leaves
 # the working tree out of sync with the snapshot git is about to commit.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,6 +7,10 @@
 # GitHub branch protection is the server-side backstop; this is the local guard.
 set -euo pipefail
 
+# Skip in CI: dedicated jobs run these checks and branch protection is enforced
+# server-side. These hooks are a local-only safety net.
+if [ -n "${CI:-}" ]; then exit 0; fi
+
 protected='^refs/heads/(main|master|release/.*)$'
 
 while read -r _local_ref _local_sha remote_ref _remote_sha; do


### PR DESCRIPTION
## Problem
The local git hooks in .githooks/ (activated via core.hooksPath) fire inside CI. create-release.yml commits a version bump and pushes to main / release/*; when the hooks are active on the runner:
- pre-commit runs dev-only checks (e.g. uvx cfn-lint) that are not installed in CI, so the commit fails.
- pre-push blocks pushes to main / release/*, so the release push fails.

## Fix
Skip both hooks when the CI environment variable is set (GitHub Actions always exports CI=true; it is unset in local shells). In CI these checks already run in dedicated jobs and GitHub branch protection is the server-side backstop, so the local hooks are redundant there. Local developer protection is unchanged.

Repo status: LATENT: hooks present and release pushes to main/release, but CI does not currently activate hooks (preventive)
Part of a fleet-wide fix across all repositories carrying these hooks.