### PR TITLE
chore(ci): test on Node 22 and 24, build and publish on 24

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Get current version
         id: current-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.check-published.outputs.already_published == 'false'
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
         env:
           NODE_AUTH_TOKEN: ''  # Clear default token to use OIDC
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,24 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+
+    # 22 is the oldest Node still in support; 24 is the LTS the consuming
+    # apps now run on. Testing only the newest would leave consumers on 22
+    # unverified. Node 18 is omitted despite engines.node — it went EOL in
+    # April 2025.
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22', '24']
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set up Node.js
+      - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
## Summary

Brings this package's CI in line with the Node 24 LTS move across the consuming apps. The test job now runs a **matrix across Node 22 and 24** instead of only 22, and the release/build workflows move to 24.

Node 22 entered Maintenance LTS on 2025-10-21 and reaches EOL on 2027-04-30; Node 24 is the current Active LTS through 2028-04-30. roboledger-app, robosystems-app, and roboinvestor-app have all moved to 24.

## Why a matrix rather than a straight bump

This matters more here than for the UI packages: an MCP client is executed directly by a Node runtime on the consumer's machine rather than bundled by an app's build step. This is a published package, so the relevant question isn't "which Node do we run" — it's "which Node do consumers run." Simply swapping `22` for `24` would leave the older supported version untested, which is precisely how a break reaches a consumer who hasn't upgraded yet. The matrix verifies both ends.

Node 18 is deliberately **not** in the matrix despite what `engines.node` allows — it reached EOL in April 2025, and spending CI on it would verify a version nobody should still be running.

## Changes

- `.github/workflows/test.yml` — `strategy.matrix.node-version: ['22', '24']`, with `fail-fast: false` so one version's failure doesn't mask the other's result
- `.github/workflows/create-release.yml` and `.github/workflows/publish.yml` — `node-version: '22'` → `'24'`. Unlike the other packages in the org, `publish.yml` here was still pinned to 22 rather than already on 24

## What is deliberately NOT changed

**`engines.node` stays as-is.** For a published package that field is a constraint imposed on every downstream consumer, not a statement about our own runtime. Raising it would be a breaking change for anyone who hasn't moved to 24 — and it's unnecessary, since the current floor already permits the Node 24 apps.

**No `package.json` or `package-lock.json` changes.** This PR touches workflow files only, so it will not conflict with a dependency-refresh PR on the same repo. The two can merge in either order.

## Testing

- Full local suite passes (`format:check`, `lint`, `typecheck`, `test`, `build`)
- Workflow YAML parsed and verified: the matrix is defined and the `setup-node` step correctly references `${{ matrix.node-version }}`

The matrix itself is exercised by CI on this PR — both legs should appear as separate checks.
