### PR TITLE
docs: correct the Node version prerequisite

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Look for issues labeled `good first issue` or `help wanted`. These are great sta
 
 ### Prerequisites
 
-- Node.js 22.x+ (check `.nvmrc`)
+- Node.js 22.x or 24.x (CI tests both)
 - npm 10.x+
 - Git configured with your GitHub account
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` told contributors to "check `.nvmrc`", but this repo has no `.nvmrc` — that pointer never resolved. It was a pre-existing doc bug, surfaced while auditing Node version claims across the fleet.

## Changes

- `.github/CONTRIBUTING.md` — prerequisites: `Node.js 22.x+ (check .nvmrc)` → `Node.js 22.x or 24.x (CI tests both)`

This replaces a dangling reference with something true and verifiable: the test workflow now runs a Node 22 and 24 matrix, so both are genuinely supported for local development.

## What is deliberately NOT changed

`engines.node` stays as-is. For a published package that field constrains every downstream consumer rather than describing our dev environment, so it is not the right thing to tie a CONTRIBUTING prerequisite to — and raising it would be a breaking release.

## Testing

Docs only. The pre-commit hook ran the full suite and it passes.
