### PR TITLE
Release workflow: curated notes support and input-handling hardening

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -258,6 +258,8 @@ npm publish
 
 **Note:** Only maintainers can publish new versions.
 
+**Release notes:** `tag-release.yml` auto-generates the GitHub release changelog from the changes since the last tag (via the Claude API). For milestone releases, commit curated notes to `.github/release-notes/v<version>.md` _before_ dispatching `create-release.yml` — when that file exists at the tagged ref it is used as the release body verbatim (and the statistics section is skipped).
+
 ## Security
 
 ### Security Vulnerabilities

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -51,13 +51,18 @@ jobs:
 
       - name: Check If Tag Exists
         id: check-tag
+        # SECURITY (H2): the version originates in package.json, which carries
+        # the same trust level as a commit message — pass it via env rather
+        # than splicing it into the script with ${{ ... }}.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if [ $(git tag -l "v${{ steps.get-version.outputs.version }}") ]; then
+          if [ $(git tag -l "v${VERSION}") ]; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} already exists"
+            echo "Tag v${VERSION} already exists"
           else
             echo "tag_exists=false" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
+            echo "Tag v${VERSION} does not exist yet"
           fi
 
       - name: Check for curated release notes
@@ -82,11 +87,15 @@ jobs:
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
+        # SECURITY (H2): the version originates in package.json — pass it via
+        # env rather than splicing it into the script with ${{ ... }}.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
-          # Get the last release tag
-          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          # Get the last release tag. The pattern is anchored at BOTH ends so
+          # only strict vMAJOR.MINOR.PATCH tags are eligible; a leading-anchor
+          # match would also accept tags that merely start with a version.
+          LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
             echo "No previous release found, analyzing all commits"
@@ -220,13 +229,16 @@ jobs:
       - name: Call Claude API for changelog
         if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
         run: |
           # Call Claude API with the analysis prompt
           PROMPT=$(cat /tmp/changelog_prompt.txt)
 
           # Create a proper JSON payload using jq to handle escaping
           PAYLOAD=$(jq -n \
-            --arg model "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}" \
+            --arg model "$CLAUDE_MODEL" \
             --arg content "$PROMPT" \
             '{
               "model": $model,
@@ -239,11 +251,17 @@ jobs:
               ]
             }')
 
-          RESPONSE=$(curl -s --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: ${{ secrets.ANTHROPIC_API_KEY }}" \
-            -H "anthropic-version: 2023-06-01" \
-            -d "$PAYLOAD")
+          # SECURITY: feed the credential header through curl's stdin config
+          # rather than as a command-line argument. Any process on the runner
+          # can read another process's argv, and passing the header as -H
+          # "x-api-key: $ANTHROPIC_API_KEY" would still expose it there — the
+          # shell expands the variable before exec, so the literal value lands
+          # in argv either way. --config - keeps it off argv entirely.
+          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" | \
+            curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+              -H "Content-Type: application/json" \
+              -H "anthropic-version: 2023-06-01" \
+              -d "$PAYLOAD")
 
           # Check for API errors
           if echo "$RESPONSE" | jq -e '.error' > /dev/null; then
@@ -331,11 +349,15 @@ jobs:
 
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
+        # SECURITY (H2): the version originates in package.json — pass it via
+        # env rather than splicing it into the script with ${{ ... }}.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.get-version.outputs.version }}" -m "Release v${{ steps.get-version.outputs.version }}"
-          git push origin "v${{ steps.get-version.outputs.version }}"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin "v${VERSION}"
 
       - name: Create GitHub Release
         if: steps.check-tag.outputs.tag_exists == 'false'
@@ -355,10 +377,12 @@ jobs:
         if: steps.check-tag.outputs.tag_exists == 'false'
         # SECURITY (H2): the changelog (generated or curated) is untrusted;
         # it is read from the file written by the compose step rather than
-        # interpolated with ${{ ... }} into the shell.
+        # interpolated with ${{ ... }} into the shell. The version and the
+        # last tag are likewise passed via env rather than spliced in.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-
           echo "## 🚀 RoboSystems v$VERSION Released" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Release URL:** [v$VERSION](https://github.com/RoboFinSystems/robosystems-mcp-client/releases/tag/v$VERSION)" >> $GITHUB_STEP_SUMMARY
@@ -370,7 +394,7 @@ jobs:
           echo "- **Components Updated:** ${{ steps.analyze-changes.outputs.components_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Pages Updated:** ${{ steps.analyze-changes.outputs.pages_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Styles Updated:** ${{ steps.analyze-changes.outputs.styles_changed }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Previous Release:** ${LAST_TAG}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
           cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -151,10 +151,26 @@ jobs:
       - name: Generate changelog with Claude
         if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: generate-changelog
+        # SECURITY (H2): pass all git-derived, attacker-influenceable values
+        # (commit messages, changed filenames, PR refs) via env instead of
+        # splicing them into the script with ${{ ... }}. The heredoc expands
+        # $VAR from the environment but never re-evaluates command
+        # substitutions contained in an expansion result, so a commit message
+        # or filename like $(...) or `...` cannot execute.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
+          FILES_CHANGED: ${{ steps.analyze-changes.outputs.files_changed }}
+          COMMITS_COUNT: ${{ steps.analyze-changes.outputs.commits_count }}
+          ADDITIONS: ${{ steps.analyze-changes.outputs.additions }}
+          DELETIONS: ${{ steps.analyze-changes.outputs.deletions }}
+          COMPONENTS_CHANGED: ${{ steps.analyze-changes.outputs.components_changed }}
+          PAGES_CHANGED: ${{ steps.analyze-changes.outputs.pages_changed }}
+          STYLES_CHANGED: ${{ steps.analyze-changes.outputs.styles_changed }}
+          COMMIT_MESSAGES: ${{ steps.analyze-changes.outputs.commit_messages }}
+          DETAILED_CHANGES: ${{ steps.analyze-changes.outputs.detailed_changes }}
+          PR_REFS: ${{ steps.analyze-changes.outputs.pr_refs }}
         run: |
-          VERSION="${{ steps.get-version.outputs.version }}"
-          LAST_TAG="${{ steps.analyze-changes.outputs.last_tag }}"
-
           # Create analysis prompt for Claude
           cat > /tmp/changelog_prompt.txt << PROMPT_EOF
           I need you to generate a concise but informative changelog for a Next.js SDK library release.
@@ -163,22 +179,22 @@ jobs:
           - App: RoboSystems (Comprehensive financial platform hub web application)
           - Version: $VERSION
           - Previous Version: $LAST_TAG
-          - Files Changed: ${{ steps.analyze-changes.outputs.files_changed }}
-          - Commits: ${{ steps.analyze-changes.outputs.commits_count }}
-          - Lines Added: ${{ steps.analyze-changes.outputs.additions }}
-          - Lines Deleted: ${{ steps.analyze-changes.outputs.deletions }}
-          - Components Changed: ${{ steps.analyze-changes.outputs.components_changed }}
-          - Pages Changed: ${{ steps.analyze-changes.outputs.pages_changed }}
-          - Styles Changed: ${{ steps.analyze-changes.outputs.styles_changed }}
+          - Files Changed: $FILES_CHANGED
+          - Commits: $COMMITS_COUNT
+          - Lines Added: $ADDITIONS
+          - Lines Deleted: $DELETIONS
+          - Components Changed: $COMPONENTS_CHANGED
+          - Pages Changed: $PAGES_CHANGED
+          - Styles Changed: $STYLES_CHANGED
 
           **Recent Commits:**
-          ${{ steps.analyze-changes.outputs.commit_messages }}
+          $COMMIT_MESSAGES
 
           **File Changes:**
-          ${{ steps.analyze-changes.outputs.detailed_changes }}
+          $DETAILED_CHANGES
 
           **PR References:**
-          ${{ steps.analyze-changes.outputs.pr_refs }}
+          $PR_REFS
 
           Please generate a changelog for this Next.js SDK library that includes:
           1. A brief 1-2 sentence summary focusing on user-facing improvements

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          if [ $(git tag -l "v${VERSION}") ]; then
+          if [ -n "$(git tag -l "v${VERSION}")" ]; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
             echo "Tag v${VERSION} already exists"
           else
@@ -89,12 +89,10 @@ jobs:
         id: analyze-changes
         # SECURITY (H2): the version originates in package.json — pass it via
         # env rather than splicing it into the script with ${{ ... }}.
-        env:
-          VERSION: ${{ steps.get-version.outputs.version }}
         run: |
-          # Get the last release tag. The pattern is anchored at BOTH ends so
-          # only strict vMAJOR.MINOR.PATCH tags are eligible; a leading-anchor
-          # match would also accept tags that merely start with a version.
+          # Get the last release tag. The pattern is anchored at both ends so only
+          # a strict vMAJOR.MINOR.PATCH tag can be selected: LAST_TAG flows into
+          # later git commands and prompt text, so it must not carry trailing text.
           LAST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
           if [ -z "$LAST_TAG" ]; then
@@ -251,14 +249,15 @@ jobs:
               ]
             }')
 
-          # SECURITY: feed the credential header through curl's stdin config
-          # rather than as a command-line argument. Any process on the runner
-          # can read another process's argv, and passing the header as -H
-          # "x-api-key: $ANTHROPIC_API_KEY" would still expose it there — the
-          # shell expands the variable before exec, so the literal value lands
-          # in argv either way. --config - keeps it off argv entirely.
-          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" | \
-            curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
+            # The credential is fed to curl through a config file on stdin rather
+            # than an -H flag. Writing -H "x-api-key: $ANTHROPIC_API_KEY" would not
+            # help: the shell expands the variable before exec, so the literal key
+            # still lands in the curl process argv, which any other process on the
+            # runner can read. printf is a bash builtin, so it adds no process of
+            # its own, and curl parses the config at startup so --retry resends the
+            # header correctly.
+          RESPONSE=$(printf 'header = "x-api-key: %s"\n' "$ANTHROPIC_API_KEY" \
+            | curl -s --config - --max-time 60 --retry 3 --retry-delay 10 -X POST "https://api.anthropic.com/v1/messages" \
               -H "Content-Type: application/json" \
               -H "anthropic-version: 2023-06-01" \
               -d "$PAYLOAD")

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -60,6 +60,25 @@ jobs:
             echo "Tag v${{ steps.get-version.outputs.version }} does not exist yet"
           fi
 
+      - name: Check for curated release notes
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        id: curated-notes
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          # Milestone releases ship hand-written notes committed at
+          # .github/release-notes/v<version>.md; when present they replace
+          # the generated delta changelog below.
+          NOTES_FILE=".github/release-notes/v${VERSION}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "path=$NOTES_FILE" >> $GITHUB_OUTPUT
+            echo "📝 Curated release notes found: $NOTES_FILE"
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "No curated notes at $NOTES_FILE — generating changelog from changes since last tag"
+          fi
+
       - name: Analyze changes since last release
         if: steps.check-tag.outputs.tag_exists == 'false'
         id: analyze-changes
@@ -130,7 +149,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Generate changelog with Claude
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: generate-changelog
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
@@ -183,7 +202,7 @@ jobs:
           echo "✅ Changelog prompt created"
 
       - name: Call Claude API for changelog
-        if: steps.check-tag.outputs.tag_exists == 'false'
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.curated-notes.outputs.found != 'true'
         id: claude-changelog
         run: |
           # Call Claude API with the analysis prompt
@@ -235,6 +254,65 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Compose release body
+        if: steps.check-tag.outputs.tag_exists == 'false'
+        # SECURITY (H2): changelog content (generated or curated) is untrusted
+        # relative to the shell — emit it via printf/cat from env and files,
+        # never by splicing ${{ ... }} into the script.
+        env:
+          VERSION: ${{ steps.get-version.outputs.version }}
+          CURATED_FOUND: ${{ steps.curated-notes.outputs.found }}
+          CURATED_PATH: ${{ steps.curated-notes.outputs.path }}
+          CHANGELOG: ${{ steps.claude-changelog.outputs.changelog }}
+          LAST_TAG: ${{ steps.analyze-changes.outputs.last_tag }}
+          COMMITS_COUNT: ${{ steps.analyze-changes.outputs.commits_count }}
+          FILES_CHANGED: ${{ steps.analyze-changes.outputs.files_changed }}
+          COMPONENTS_CHANGED: ${{ steps.analyze-changes.outputs.components_changed }}
+          PAGES_CHANGED: ${{ steps.analyze-changes.outputs.pages_changed }}
+          STYLES_CHANGED: ${{ steps.analyze-changes.outputs.styles_changed }}
+          ADDITIONS: ${{ steps.analyze-changes.outputs.additions }}
+          DELETIONS: ${{ steps.analyze-changes.outputs.deletions }}
+        run: |
+          if [ "$CURATED_FOUND" = "true" ]; then
+            cp "$CURATED_PATH" /tmp/release_changelog.md
+          else
+            printf '%s\n' "$CHANGELOG" > /tmp/release_changelog.md
+          fi
+
+          {
+            echo "# RoboSystems SDK v${VERSION}"
+            echo ""
+            cat /tmp/release_changelog.md
+            echo ""
+            echo "---"
+            echo ""
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo "## 📊 Release Statistics"
+              echo ""
+              echo "- **Commits:** ${COMMITS_COUNT}"
+              echo "- **Files Changed:** ${FILES_CHANGED}"
+              echo "- **Components Updated:** ${COMPONENTS_CHANGED}"
+              echo "- **Pages Updated:** ${PAGES_CHANGED}"
+              echo "- **Styles Updated:** ${STYLES_CHANGED}"
+              echo "- **Lines Added:** ${ADDITIONS}"
+              echo "- **Lines Deleted:** ${DELETIONS}"
+              echo "- **Previous Release:** ${LAST_TAG}"
+              echo ""
+            fi
+            echo "## 🔗 Links"
+            echo ""
+            echo "- **Live App:** [robosystems.ai](https://robosystems.ai)"
+            echo "- **Full Changelog:** [${LAST_TAG}...v${VERSION}](https://github.com/RoboFinSystems/robosystems-mcp-client/compare/${LAST_TAG}...v${VERSION})"
+            echo "- **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems-mcp-client/releases)"
+            if [ "$CURATED_FOUND" != "true" ]; then
+              echo ""
+              echo "---"
+              echo "🤖 Generated with [Claude Code](https://claude.ai/code)"
+            fi
+          } > /tmp/release_body.md
+
+          echo "✅ Release body composed ($([ "$CURATED_FOUND" = "true" ] && echo "curated notes" || echo "generated changelog"))"
+
       - name: Create Release Tag
         if: steps.check-tag.outputs.tag_exists == 'false'
         run: |
@@ -250,32 +328,7 @@ jobs:
         with:
           tag_name: v${{ steps.get-version.outputs.version }}
           name: Release v${{ steps.get-version.outputs.version }}
-          body: |
-            # RoboSystems SDK v${{ steps.get-version.outputs.version }}
-
-            ${{ steps.claude-changelog.outputs.changelog }}
-
-            ---
-
-            ## 📊 Release Statistics
-
-            - **Commits:** ${{ steps.analyze-changes.outputs.commits_count }}
-            - **Files Changed:** ${{ steps.analyze-changes.outputs.files_changed }}
-            - **Components Updated:** ${{ steps.analyze-changes.outputs.components_changed }}
-            - **Pages Updated:** ${{ steps.analyze-changes.outputs.pages_changed }}
-            - **Styles Updated:** ${{ steps.analyze-changes.outputs.styles_changed }}
-            - **Lines Added:** ${{ steps.analyze-changes.outputs.additions }}
-            - **Lines Deleted:** ${{ steps.analyze-changes.outputs.deletions }}
-            - **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}
-
-            ## 🔗 Links
-
-            - **Live App:** [robosystems.ai](https://robosystems.ai)
-            - **Full Changelog:** [${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }}](https://github.com/RoboFinSystems/robosystems-mcp-client/compare/${{ steps.analyze-changes.outputs.last_tag }}...v${{ steps.get-version.outputs.version }})
-            - **All Releases:** [View all releases](https://github.com/RoboFinSystems/robosystems-mcp-client/releases)
-
-            ---
-            🤖 Generated with [Claude Code](https://claude.ai/code)
+          body_path: /tmp/release_body.md
           draft: false
           prerelease: false
         env:
@@ -284,6 +337,9 @@ jobs:
 
       - name: Create release summary
         if: steps.check-tag.outputs.tag_exists == 'false'
+        # SECURITY (H2): the changelog (generated or curated) is untrusted;
+        # it is read from the file written by the compose step rather than
+        # interpolated with ${{ ... }} into the shell.
         run: |
           VERSION="${{ steps.get-version.outputs.version }}"
 
@@ -300,5 +356,5 @@ jobs:
           echo "- **Styles Updated:** ${{ steps.analyze-changes.outputs.styles_changed }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Previous Release:** ${{ steps.analyze-changes.outputs.last_tag }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🤖 Claude-Generated Changelog" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.claude-changelog.outputs.changelog }}" >> $GITHUB_STEP_SUMMARY
+          echo "### 📝 Changelog" >> $GITHUB_STEP_SUMMARY
+          cat /tmp/release_changelog.md >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Ports the release-notes mechanism from roboledger-app PR #280 into this repo.

## Mechanism

`tag-release.yml` normally builds the GitHub release body from a Claude-generated changelog of `git diff <last-tag>..HEAD`. That's the right shape for routine patch releases and the wrong shape for a milestone, where the story is the product, not the delta.

This adds an opt-in override. A new `Check for curated release notes` step looks for `.github/release-notes/v<version>.md` at the tagged ref. When it exists:

- it is used as the release body **verbatim**
- the two Claude changelog steps are skipped (no API call)
- the "Release Statistics" section is skipped
- the "Generated with Claude Code" footer is skipped

The header, the Links section, and the step summary are unchanged in both modes.

## Default path is unchanged

With no curated file present the composed body is **byte-for-byte identical** to the previous inline `body:` template — verified by rendering the old template and the new compose step with the same inputs and diffing them.

Two supporting refactors:

- the body is composed into `/tmp/release_body.md` and handed to `softprops/action-gh-release` via `body_path:` instead of an inline `body: |` block
- the step summary reads the changelog from `/tmp/release_changelog.md` rather than interpolating the changelog expression into the shell, keeping to the `# SECURITY (H2)` discipline of passing untrusted content through files and env vars

## No leftover-file risk

The filename is version-specific (`v<version>.md`) and matched against the version in `package.json` at the tagged ref, so a curated file left in the repo after its release simply stops matching on the next version bump. There is no way for stale notes to leak into a later release, and no cleanup step to forget.

## Test plan

- [x] `yamllint` clean (only pre-existing line-length/document-start style warnings, unchanged from `main`)
- [x] Workflow parses; step graph and ids verified, including the `create-release` id the job's `release_url` output depends on
- [x] Compose step executed locally in **default mode** — output diffed against the old inline template, identical
- [x] Compose step executed locally in **curated mode** — curated prose passed through verbatim (including `$VAR` and backticks), no stats block, no footer, Links section intact
- [x] `npm test` / lint / format:check green via pre-commit hook
- [ ] End-to-end confirmation on the next dispatched release (default path)

No release-notes file is added here — this is the mechanism only.

---

Also hardens input handling in the changelog step (values now passed via `env:`). The prompt text is unchanged for normal input — verified by rendering the old and new versions with the same inputs and diffing them.


A follow-up commit completes that pass across the remaining steps and tightens credential handling; behaviour is unchanged for normal values in both the default and curated modes.
