### PR TITLE
feat(proxy): streamable HTTP proxy mode for stdio clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@
 
 Official MCP (Model Context Protocol) stdio bridge for connecting stdio-only AI clients to the RoboSystems Financial Knowledge Graph API. Query financial statements, explore graph structures, resolve XBRL elements, and build fact grids.
 
-> **The preferred way to connect is the hosted remote MCP endpoint — no install required.** Every RoboSystems graph serves the MCP Streamable HTTP transport directly: add `https://api.robosystems.ai/v1/graphs/{graph_id}/mcp` as a connector with your API key in the `X-API-Key` header, and Claude Code, Cursor, VS Code, or any HTTP-capable MCP client connects with zero setup. **This npx bridge is in maintenance mode** — it remains published and supported for clients that only speak the stdio transport, and for those clients [proxy mode](#proxy-mode-recommended-for-stdio-clients) forwards the same modern transport over stdio. See [Migrating to the remote endpoint](#migrating-to-the-remote-endpoint).
+> **The preferred way to connect is the hosted remote MCP endpoint — no install required.** Every RoboSystems graph serves the MCP Streamable HTTP transport directly: add `https://api.robosystems.ai/v1/graphs/{graph_id}/mcp` as a connector with your API key in the `X-API-Key` header, and Claude Code, Cursor, VS Code, or any HTTP-capable MCP client connects with zero setup. **This npx package is in maintenance mode** and exists for clients that only speak the stdio transport: by default it runs in [proxy mode](#proxy-mode-the-default), forwarding that same modern transport over stdio. See [Migrating to the remote endpoint](#migrating-to-the-remote-endpoint).
 
 ## Features
 
+- **Native MCP transport over stdio** — the default proxy mode forwards the graph's Streamable HTTP endpoint verbatim: per-session instructions, live tool lists, and streamed progress notifications, identical to connecting the URL directly
 - **Financial data tools** for statements, disclosures, and multidimensional fact grids
 - **Graph exploration** with Cypher queries, schema introspection, and element resolution
 - **Workspace management** for isolated subgraphs, staging data, and persistent agent memory
-- **Streaming support** via SSE and NDJSON for large result sets
-- **Connection pooling** with LRU eviction for optimal performance
-- **Smart caching** for frequently accessed schemas and metadata
-- **Automatic retry logic** with exponential backoff
+- **Legacy bridge mode** for pre-v1.7.0 servers, with client-side SSE/NDJSON aggregation, smart caching, and retry logic
 
 ## Installation
 
@@ -39,37 +37,23 @@ Add to your MCP servers configuration:
 
 ### Environment Variables
 
-| Variable               | Description                                                    | Default                      |
-| ---------------------- | -------------------------------------------------------------- | ---------------------------- |
-| `ROBOSYSTEMS_API_KEY`  | Your API key                                                   | _(required)_                 |
-| `ROBOSYSTEMS_GRAPH_ID` | Primary graph ID (parent for workspaces)                       | _(required)_                 |
-| `ROBOSYSTEMS_API_URL`  | API endpoint                                                   | `https://api.robosystems.ai` |
-| `ROBOSYSTEMS_MCP_MODE` | Set to `proxy` to forward the native MCP transport (see below) | _(legacy bridge)_            |
-| `ROBOSYSTEMS_MCP_URL`  | Full MCP endpoint URL — setting it implies proxy mode          | _(derived from graph ID)_    |
+| Variable               | Description                                                        | Default                      |
+| ---------------------- | ------------------------------------------------------------------ | ---------------------------- |
+| `ROBOSYSTEMS_API_KEY`  | Your API key                                                       | _(required)_                 |
+| `ROBOSYSTEMS_GRAPH_ID` | Primary graph ID (parent for workspaces)                           | _(required)_                 |
+| `ROBOSYSTEMS_API_URL`  | API endpoint                                                       | `https://api.robosystems.ai` |
+| `ROBOSYSTEMS_MCP_MODE` | Set to `legacy` to run the old REST-aggregation bridge (see below) | `proxy`                      |
+| `ROBOSYSTEMS_MCP_URL`  | Full MCP endpoint URL — overrides the URL derived from graph ID    | _(derived from graph ID)_    |
 
-### Proxy Mode (recommended for stdio clients)
+### Proxy Mode (the default)
 
-Proxy mode turns this package into a transparent pipe between your stdio client and the graph's native MCP endpoint (`POST /v1/graphs/{graph_id}/mcp`, Streamable HTTP). Every JSON-RPC message is forwarded verbatim, so per-session instructions, the live server tool list, and streamed progress notifications behave exactly as they do when connecting the URL directly — the only thing the proxy adds is the API-key header the stdio client can't send itself. Add `ROBOSYSTEMS_MCP_MODE: "proxy"` to the config above:
+By default this package is a transparent pipe between your stdio client and the graph's native MCP endpoint (`POST /v1/graphs/{graph_id}/mcp`, Streamable HTTP). Every JSON-RPC message is forwarded verbatim, so per-session instructions, the live server tool list, and streamed progress notifications behave exactly as they do when connecting the URL directly — the only thing the proxy adds is the API-key header the stdio client can't send itself. The standard configuration above is all it needs.
 
-```json
-{
-  "mcpServers": {
-    "robosystems": {
-      "command": "npx",
-      "args": ["-y", "@robosystems/mcp@latest"],
-      "env": {
-        "ROBOSYSTEMS_MCP_MODE": "proxy",
-        "ROBOSYSTEMS_API_KEY": "rfs...",
-        "ROBOSYSTEMS_GRAPH_ID": "kg..."
-      }
-    }
-  }
-}
-```
+To target a specific endpoint (for example a local stack), point `ROBOSYSTEMS_MCP_URL` at the full URL, e.g. `http://localhost:8000/v1/graphs/kg.../mcp` — no graph ID needed.
 
-Alternatively, point `ROBOSYSTEMS_MCP_URL` at any MCP endpoint URL (for example `http://localhost:8000/v1/graphs/kg.../mcp` against a local stack) — setting it activates proxy mode without a graph ID.
+### Legacy Bridge Mode
 
-Without the mode flag, the package runs the legacy bridge: it aggregates the REST tool endpoints client-side and adds its own workspace-switching tools. The legacy bridge remains the default so existing configurations keep their current behavior, but new stdio setups should prefer proxy mode.
+Set `ROBOSYSTEMS_MCP_MODE: "legacy"` to run the original bridge, which aggregates the REST tool endpoints (`GET /mcp/tools` + `POST /mcp/call-tool`) client-side and adds its own workspace-switching tools. You only need this against an API deployment that predates the MCP transport (server versions before v1.7.0), or if you depend on the bridge's client-side `create-workspace`/`switch-workspace` tool names — current servers expose the same capabilities as `create-subgraph`/`switch-workspace` tools natively.
 
 ## Migrating to the Remote Endpoint
 
@@ -94,11 +78,11 @@ claude mcp add --transport http robosystems-sec \
 
 Local development uses the same shape against a local stack: `http://localhost:8000/v1/graphs/{graph_id}/mcp`.
 
-**Claude (claude.ai / Desktop) cannot use the remote endpoint directly yet** — its custom connectors authenticate with OAuth only and have no custom-header field, so they cannot send an API key. Claude Desktop users should run this package in [proxy mode](#proxy-mode-recommended-for-stdio-clients) via `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries), which delivers the full remote-endpoint behavior over stdio, until OAuth support lands on the platform.
+**Claude (claude.ai / Desktop) cannot use the remote endpoint directly yet** — its custom connectors authenticate with OAuth only and have no custom-header field, so they cannot send an API key. Claude Desktop users should run this package via `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries); in its default [proxy mode](#proxy-mode-the-default) it delivers the full remote-endpoint behavior over stdio.
 
 ## Tools
 
-Tools are loaded dynamically from the RoboSystems API based on your graph. The client also provides built-in workspace management tools.
+Tools are loaded dynamically from the RoboSystems API based on your graph. In legacy bridge mode the client additionally provides its own workspace management tools (in proxy mode the server serves the equivalent subgraph tools natively).
 
 ### Financial Data
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Official MCP (Model Context Protocol) stdio bridge for connecting stdio-only AI clients to the RoboSystems Financial Knowledge Graph API. Query financial statements, explore graph structures, resolve XBRL elements, and build fact grids.
 
-> **The preferred way to connect is the hosted remote MCP endpoint — no install required.** Every RoboSystems graph serves the MCP Streamable HTTP transport directly: add `https://api.robosystems.ai/v1/graphs/{graph_id}/mcp` as a connector with your API key in the `X-API-Key` header, and Claude Code, Cursor, VS Code, or any HTTP-capable MCP client connects with zero setup. **This npx bridge is in maintenance mode** — it remains published and supported for clients that only speak the stdio transport, but new setups should use the remote endpoint. See [Migrating to the remote endpoint](#migrating-to-the-remote-endpoint).
+> **The preferred way to connect is the hosted remote MCP endpoint — no install required.** Every RoboSystems graph serves the MCP Streamable HTTP transport directly: add `https://api.robosystems.ai/v1/graphs/{graph_id}/mcp` as a connector with your API key in the `X-API-Key` header, and Claude Code, Cursor, VS Code, or any HTTP-capable MCP client connects with zero setup. **This npx bridge is in maintenance mode** — it remains published and supported for clients that only speak the stdio transport, and for those clients [proxy mode](#proxy-mode-recommended-for-stdio-clients) forwards the same modern transport over stdio. See [Migrating to the remote endpoint](#migrating-to-the-remote-endpoint).
 
 ## Features
 
@@ -39,11 +39,37 @@ Add to your MCP servers configuration:
 
 ### Environment Variables
 
-| Variable               | Description                              | Default                      |
-| ---------------------- | ---------------------------------------- | ---------------------------- |
-| `ROBOSYSTEMS_API_KEY`  | Your API key                             | _(required)_                 |
-| `ROBOSYSTEMS_GRAPH_ID` | Primary graph ID (parent for workspaces) | _(required)_                 |
-| `ROBOSYSTEMS_API_URL`  | API endpoint                             | `https://api.robosystems.ai` |
+| Variable               | Description                                                    | Default                      |
+| ---------------------- | -------------------------------------------------------------- | ---------------------------- |
+| `ROBOSYSTEMS_API_KEY`  | Your API key                                                   | _(required)_                 |
+| `ROBOSYSTEMS_GRAPH_ID` | Primary graph ID (parent for workspaces)                       | _(required)_                 |
+| `ROBOSYSTEMS_API_URL`  | API endpoint                                                   | `https://api.robosystems.ai` |
+| `ROBOSYSTEMS_MCP_MODE` | Set to `proxy` to forward the native MCP transport (see below) | _(legacy bridge)_            |
+| `ROBOSYSTEMS_MCP_URL`  | Full MCP endpoint URL — setting it implies proxy mode          | _(derived from graph ID)_    |
+
+### Proxy Mode (recommended for stdio clients)
+
+Proxy mode turns this package into a transparent pipe between your stdio client and the graph's native MCP endpoint (`POST /v1/graphs/{graph_id}/mcp`, Streamable HTTP). Every JSON-RPC message is forwarded verbatim, so per-session instructions, the live server tool list, and streamed progress notifications behave exactly as they do when connecting the URL directly — the only thing the proxy adds is the API-key header the stdio client can't send itself. Add `ROBOSYSTEMS_MCP_MODE: "proxy"` to the config above:
+
+```json
+{
+  "mcpServers": {
+    "robosystems": {
+      "command": "npx",
+      "args": ["-y", "@robosystems/mcp@latest"],
+      "env": {
+        "ROBOSYSTEMS_MCP_MODE": "proxy",
+        "ROBOSYSTEMS_API_KEY": "rfs...",
+        "ROBOSYSTEMS_GRAPH_ID": "kg..."
+      }
+    }
+  }
+}
+```
+
+Alternatively, point `ROBOSYSTEMS_MCP_URL` at any MCP endpoint URL (for example `http://localhost:8000/v1/graphs/kg.../mcp` against a local stack) — setting it activates proxy mode without a graph ID.
+
+Without the mode flag, the package runs the legacy bridge: it aggregates the REST tool endpoints client-side and adds its own workspace-switching tools. The legacy bridge remains the default so existing configurations keep their current behavior, but new stdio setups should prefer proxy mode.
 
 ## Migrating to the Remote Endpoint
 
@@ -68,7 +94,7 @@ claude mcp add --transport http robosystems-sec \
 
 Local development uses the same shape against a local stack: `http://localhost:8000/v1/graphs/{graph_id}/mcp`.
 
-**Claude (claude.ai / Desktop) cannot use the remote endpoint yet** — its custom connectors authenticate with OAuth only and have no custom-header field, so they cannot send an API key. Claude Desktop users should keep using this bridge in `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries) until OAuth support lands on the platform.
+**Claude (claude.ai / Desktop) cannot use the remote endpoint directly yet** — its custom connectors authenticate with OAuth only and have no custom-header field, so they cannot send an API key. Claude Desktop users should run this package in [proxy mode](#proxy-mode-recommended-for-stdio-clients) via `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries), which delivers the full remote-endpoint behavior over stdio, until OAuth support lands on the platform.
 
 ## Tools
 

--- a/index.js
+++ b/index.js
@@ -1228,19 +1228,21 @@ async function main() {
   const apiKey = process.env.ROBOSYSTEMS_API_KEY
   const graphId = process.env.ROBOSYSTEMS_GRAPH_ID
 
-  // Proxy mode: forward stdio JSON-RPC straight to the platform's native MCP
-  // endpoint (Streamable HTTP) instead of running the legacy REST bridge.
-  // Activated by ROBOSYSTEMS_MCP_MODE=proxy, a --proxy flag, or by pointing
-  // ROBOSYSTEMS_MCP_URL at a full MCP endpoint URL.
+  // Proxy mode (the default): forward stdio JSON-RPC straight to the
+  // platform's native MCP endpoint (Streamable HTTP) instead of running the
+  // legacy REST bridge. ROBOSYSTEMS_MCP_MODE=legacy opts back into the bridge
+  // (needed only against API deployments predating the MCP transport, or for
+  // the bridge's client-side workspace tools); ROBOSYSTEMS_MCP_URL or a
+  // --proxy flag force proxy mode regardless.
   const mcpUrl = process.env.ROBOSYSTEMS_MCP_URL
-  const proxyMode =
-    Boolean(mcpUrl) ||
-    process.env.ROBOSYSTEMS_MCP_MODE === 'proxy' ||
-    process.argv.includes('--proxy')
+  const legacyMode =
+    !mcpUrl &&
+    !process.argv.includes('--proxy') &&
+    (process.env.ROBOSYSTEMS_MCP_MODE === 'legacy' || process.env.ROBOSYSTEMS_MCP_MODE === 'bridge')
 
-  if (proxyMode) {
+  if (!legacyMode) {
     if (!mcpUrl && !graphId) {
-      console.error('Proxy mode requires ROBOSYSTEMS_MCP_URL or ROBOSYSTEMS_GRAPH_ID')
+      console.error('ROBOSYSTEMS_GRAPH_ID (or a full ROBOSYSTEMS_MCP_URL) is required')
       console.error('Set one of them in your MCP configuration')
       process.exit(1)
     }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import { EventSource } from 'eventsource'
+import { runProxy } from './proxy.js'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
@@ -1226,6 +1227,28 @@ async function main() {
   const baseUrl = process.env.ROBOSYSTEMS_API_URL || 'https://api.robosystems.ai'
   const apiKey = process.env.ROBOSYSTEMS_API_KEY
   const graphId = process.env.ROBOSYSTEMS_GRAPH_ID
+
+  // Proxy mode: forward stdio JSON-RPC straight to the platform's native MCP
+  // endpoint (Streamable HTTP) instead of running the legacy REST bridge.
+  // Activated by ROBOSYSTEMS_MCP_MODE=proxy, a --proxy flag, or by pointing
+  // ROBOSYSTEMS_MCP_URL at a full MCP endpoint URL.
+  const mcpUrl = process.env.ROBOSYSTEMS_MCP_URL
+  const proxyMode =
+    Boolean(mcpUrl) ||
+    process.env.ROBOSYSTEMS_MCP_MODE === 'proxy' ||
+    process.argv.includes('--proxy')
+
+  if (proxyMode) {
+    if (!mcpUrl && !graphId) {
+      console.error('Proxy mode requires ROBOSYSTEMS_MCP_URL or ROBOSYSTEMS_GRAPH_ID')
+      console.error('Set one of them in your MCP configuration')
+      process.exit(1)
+    }
+    const url = mcpUrl || `${baseUrl.replace(/\/$/, '')}/v1/graphs/${graphId}/mcp`
+    void checkForUpdate() // fire-and-forget stale-version warning (stderr only)
+    await runProxy({ url, apiKey, version: PACKAGE_VERSION })
+    return
+  }
 
   if (!apiKey) {
     console.error('ROBOSYSTEMS_API_KEY environment variable is required')

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "index.js",
+    "proxy.js",
     "README.md",
     "LICENSE"
   ],

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,217 @@
+/**
+ * Streamable HTTP proxy mode.
+ *
+ * Instead of impersonating the MCP server over the REST tool endpoints
+ * (GET /mcp/tools + POST /mcp/call-tool), this mode is a transparent pipe
+ * between a stdio MCP client (Claude Desktop, or any stdio-only host) and the
+ * platform's native MCP endpoint (POST /v1/graphs/{graph_id}/mcp, Streamable
+ * HTTP). Every JSON-RPC message read from stdin is forwarded verbatim with the
+ * API key header attached; JSON and SSE responses are relayed back to stdout
+ * message-for-message. Per-session instructions, live tool lists, and streamed
+ * progress notifications all pass through untouched — connecting through the
+ * proxy behaves identically to connecting the URL directly.
+ */
+
+import { createInterface } from 'readline'
+
+const JSONRPC_PARSE_ERROR = -32700
+const JSONRPC_PROXY_ERROR = -32000
+const ERROR_BODY_PREVIEW_CHARS = 300
+
+/**
+ * Parse a Server-Sent Events stream and deliver each event's JSON payload.
+ * Handles multi-line `data:` fields per the SSE spec and ignores comment
+ * (keepalive) lines. `event:`/`id:`/`retry:` fields carry no JSON-RPC content
+ * on this endpoint and are skipped.
+ */
+async function relaySSE(body, deliver) {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let dataLines = []
+
+  const dispatch = () => {
+    if (dataLines.length === 0) return
+    const dataStr = dataLines.join('\n')
+    dataLines = []
+    if (!dataStr || dataStr === '[DONE]') return
+    try {
+      deliver(JSON.parse(dataStr))
+    } catch {
+      console.error('Proxy: skipping unparseable SSE event')
+    }
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() || ''
+
+      for (const line of lines) {
+        if (line === '') {
+          dispatch()
+        } else if (line.startsWith(':')) {
+          // Comment / keepalive — ignore
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).replace(/^ /, ''))
+        }
+      }
+    }
+    // Flush a trailing event if the stream ended without a final blank line
+    if (buffer.startsWith('data:')) {
+      dataLines.push(buffer.slice(5).replace(/^ /, ''))
+    }
+    dispatch()
+  } finally {
+    reader.cancel().catch(() => {})
+  }
+}
+
+/**
+ * Create a proxy instance bound to one MCP endpoint. Exposed separately from
+ * runProxy so tests can drive individual messages without real stdio.
+ */
+export function createProxy({ url, apiKey, version, output = process.stdout, fetchImpl = fetch }) {
+  // Captured from the initialize response and echoed back on subsequent
+  // requests via the MCP-Protocol-Version header, per Streamable HTTP.
+  let protocolVersion = null
+
+  const deliver = (message) => {
+    if (message && typeof message === 'object' && message.result?.protocolVersion) {
+      protocolVersion = message.result.protocolVersion
+    }
+    output.write(JSON.stringify(message) + '\n')
+  }
+
+  const buildHeaders = () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'User-Agent': `robosystems-mcp/${version}`,
+      'X-MCP-Client': version,
+    }
+    if (apiKey) {
+      headers['X-API-Key'] = apiKey
+    }
+    if (protocolVersion) {
+      headers['MCP-Protocol-Version'] = protocolVersion
+    }
+    return headers
+  }
+
+  const handleLine = async (line) => {
+    const raw = line.trim()
+    if (!raw) return
+
+    let message
+    try {
+      message = JSON.parse(raw)
+    } catch {
+      deliver({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: JSONRPC_PARSE_ERROR, message: 'Parse error' },
+      })
+      return
+    }
+
+    // Requests carry both a method and an id and expect a reply; notifications
+    // and client→server responses get forwarded but never answered locally.
+    const expectsResponse = message.method !== undefined && message.id !== undefined
+
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: buildHeaders(),
+        body: raw,
+      })
+
+      // 202 Accepted — notification or response delivered, nothing to relay
+      if (response.status === 202) return
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => '')
+        if (expectsResponse) {
+          const detail = text ? `: ${text.slice(0, ERROR_BODY_PREVIEW_CHARS)}` : ''
+          deliver({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: {
+              code: JSONRPC_PROXY_ERROR,
+              message: `HTTP ${response.status}${detail}`,
+            },
+          })
+        } else {
+          console.error(`Proxy: HTTP ${response.status} forwarding ${message.method || 'response'}`)
+        }
+        return
+      }
+
+      const contentType = response.headers.get('content-type') || ''
+      if (contentType.includes('text/event-stream')) {
+        await relaySSE(response.body, deliver)
+      } else {
+        const text = await response.text()
+        if (!text.trim()) return
+        // Re-serialize to guarantee one message per stdout line
+        deliver(JSON.parse(text))
+      }
+    } catch (error) {
+      if (expectsResponse) {
+        deliver({
+          jsonrpc: '2.0',
+          id: message.id,
+          error: {
+            code: JSONRPC_PROXY_ERROR,
+            message: `Proxy request failed: ${error.message}`,
+          },
+        })
+      } else {
+        console.error(`Proxy request failed: ${error.message}`)
+      }
+    }
+  }
+
+  return {
+    handleLine,
+    getProtocolVersion: () => protocolVersion,
+  }
+}
+
+/**
+ * Run the proxy over real stdio until the host closes stdin.
+ */
+export async function runProxy({
+  url,
+  apiKey,
+  version,
+  input = process.stdin,
+  output = process.stdout,
+  fetchImpl = fetch,
+}) {
+  const proxy = createProxy({ url, apiKey, version, output, fetchImpl })
+
+  console.error(`RoboSystems MCP proxy v${version}`)
+  console.error(`Forwarding stdio <-> ${url}`)
+  if (!apiKey) {
+    console.error(
+      'No ROBOSYSTEMS_API_KEY set — forwarding without an X-API-Key header ' +
+        '(fine only if the endpoint URL itself carries credentials)'
+    )
+  }
+
+  const pending = new Set()
+  const rl = createInterface({ input, terminal: false })
+
+  rl.on('line', (line) => {
+    const task = proxy.handleLine(line).finally(() => pending.delete(task))
+    pending.add(task)
+  })
+
+  await new Promise((resolve) => rl.on('close', resolve))
+  await Promise.allSettled([...pending])
+}

--- a/proxy.test.js
+++ b/proxy.test.js
@@ -1,0 +1,236 @@
+/**
+ * Tests for Streamable HTTP proxy mode
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { Readable } from 'stream'
+import { ReadableStream } from 'stream/web'
+import { TextEncoder } from 'util'
+import { createProxy, runProxy } from './proxy.js'
+
+const URL = 'https://api.example.com/v1/graphs/kg123/mcp'
+
+function makeOutput() {
+  const lines = []
+  return {
+    write: (chunk) => {
+      lines.push(chunk)
+      return true
+    },
+    lines,
+    messages: () => lines.map((l) => JSON.parse(l)),
+  }
+}
+
+function jsonResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name) => (name.toLowerCase() === 'content-type' ? 'application/json' : null) },
+    text: async () => JSON.stringify(body),
+  }
+}
+
+function sseResponse(sseText) {
+  const encoder = new TextEncoder()
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(sseText))
+      controller.close()
+    },
+  })
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name) => (name.toLowerCase() === 'content-type' ? 'text/event-stream' : null),
+    },
+    body,
+  }
+}
+
+function acceptedResponse() {
+  return {
+    ok: true,
+    status: 202,
+    headers: { get: () => null },
+    text: async () => '',
+  }
+}
+
+describe('createProxy', () => {
+  it('forwards a request verbatim and writes the JSON response as one line', async () => {
+    const response = { jsonrpc: '2.0', id: 1, result: { tools: [] } }
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(response))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'test-key', version: '0.0.0', output, fetchImpl })
+
+    const request = '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+    await proxy.handleLine(request)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, options] = fetchImpl.mock.calls[0]
+    expect(url).toBe(URL)
+    expect(options.method).toBe('POST')
+    expect(options.body).toBe(request)
+    expect(options.headers['X-API-Key']).toBe('test-key')
+    expect(options.headers.Accept).toBe('application/json, text/event-stream')
+
+    expect(output.lines).toHaveLength(1)
+    expect(output.lines[0].endsWith('\n')).toBe(true)
+    expect(output.messages()[0]).toEqual(response)
+  })
+
+  it('captures the negotiated protocol version and echoes it on later requests', async () => {
+    const initResult = {
+      jsonrpc: '2.0',
+      id: 0,
+      result: { protocolVersion: '2025-06-18', capabilities: {}, serverInfo: { name: 's' } },
+    }
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(initResult))
+      .mockResolvedValueOnce(jsonResponse({ jsonrpc: '2.0', id: 1, result: { tools: [] } }))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}')
+    expect(fetchImpl.mock.calls[0][1].headers['MCP-Protocol-Version']).toBeUndefined()
+    expect(proxy.getProtocolVersion()).toBe('2025-06-18')
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')
+    expect(fetchImpl.mock.calls[1][1].headers['MCP-Protocol-Version']).toBe('2025-06-18')
+  })
+
+  it('relays each SSE event as its own line and ignores keepalive comments', async () => {
+    const progress = {
+      jsonrpc: '2.0',
+      method: 'notifications/progress',
+      params: { progressToken: 't', progress: 50 },
+    }
+    const result = { jsonrpc: '2.0', id: 2, result: { content: [{ type: 'text', text: 'done' }] } }
+    const sseText =
+      `data: ${JSON.stringify(progress)}\n\n` +
+      ': keepalive\n\n' +
+      `data: ${JSON.stringify(result)}\n\n`
+    const fetchImpl = vi.fn().mockResolvedValue(sseResponse(sseText))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{}}')
+
+    expect(output.messages()).toEqual([progress, result])
+  })
+
+  it('joins multi-line SSE data fields before parsing', async () => {
+    const result = { jsonrpc: '2.0', id: 3, result: { ok: true } }
+    const json = JSON.stringify(result)
+    const mid = Math.floor(json.length / 2)
+    const sseText = `data: ${json.slice(0, mid)}\ndata: ${json.slice(mid)}\n\n`
+    const fetchImpl = vi.fn().mockResolvedValue(sseResponse(sseText))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{}}')
+
+    // Multi-line data is joined with \n per the SSE spec; JSON tolerates the
+    // embedded newline, so the payload must round-trip
+    expect(output.messages()).toEqual([result])
+  })
+
+  it('writes nothing for a 202-accepted notification', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(acceptedResponse())
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","method":"notifications/initialized"}')
+
+    expect(output.lines).toHaveLength(0)
+  })
+
+  it('synthesizes a JSON-RPC error for an HTTP error on a request', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: { get: () => 'application/json' },
+      text: async () => '{"detail":"Invalid API key or access denied"}',
+    })
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'bad', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":7,"method":"tools/list","params":{}}')
+
+    const [message] = output.messages()
+    expect(message.id).toBe(7)
+    expect(message.error.code).toBe(-32000)
+    expect(message.error.message).toContain('HTTP 403')
+  })
+
+  it('logs but does not answer an HTTP error on a notification', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: { get: () => null },
+      text: async () => 'oops',
+    })
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","method":"notifications/cancelled"}')
+
+    expect(output.lines).toHaveLength(0)
+  })
+
+  it('synthesizes a JSON-RPC error when the network request fails', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('socket hang up'))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":9,"method":"tools/list","params":{}}')
+
+    const [message] = output.messages()
+    expect(message.id).toBe(9)
+    expect(message.error.code).toBe(-32000)
+    expect(message.error.message).toContain('socket hang up')
+  })
+
+  it('answers an unparseable stdin line with a parse error', async () => {
+    const fetchImpl = vi.fn()
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: 'k', version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('not json at all')
+
+    expect(fetchImpl).not.toHaveBeenCalled()
+    const [message] = output.messages()
+    expect(message.error.code).toBe(-32700)
+    expect(message.id).toBeNull()
+  })
+
+  it('skips blank stdin lines and omits the API key header when unset', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ jsonrpc: '2.0', id: 1, result: {} }))
+    const output = makeOutput()
+    const proxy = createProxy({ url: URL, apiKey: undefined, version: '0.0.0', output, fetchImpl })
+
+    await proxy.handleLine('')
+    await proxy.handleLine('   ')
+    expect(fetchImpl).not.toHaveBeenCalled()
+
+    await proxy.handleLine('{"jsonrpc":"2.0","id":1,"method":"ping"}')
+    expect(fetchImpl.mock.calls[0][1].headers['X-API-Key']).toBeUndefined()
+  })
+})
+
+describe('runProxy', () => {
+  it('pipes stdin lines through to the endpoint and responses back out', async () => {
+    const response = { jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'robosystems' } } }
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(response))
+    const output = makeOutput()
+    const input = Readable.from(['{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n'])
+
+    await runProxy({ url: URL, apiKey: 'k', version: '0.0.0', input, output, fetchImpl })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(output.messages()).toEqual([response])
+  })
+})


### PR DESCRIPTION
## Summary

Adds **proxy mode** — a transparent stdio ⇄ Streamable HTTP pipe to the graph's native MCP endpoint (`POST /v1/graphs/{graph_id}/mcp`) — **and makes it the default**. The legacy REST-aggregation bridge stays available behind `ROBOSYSTEMS_MCP_MODE=legacy`.

- Every JSON-RPC message from stdin is forwarded verbatim with the `X-API-Key` header attached; JSON and SSE responses relay back to stdout message-for-message
- Per-session `instructions`, the live server tool list, and streamed `notifications/progress` all pass through untouched — behavior is identical to connecting the URL directly
- Captures the negotiated `protocolVersion` from initialize and echoes it via `MCP-Protocol-Version` on subsequent requests
- **Proxy is the default**: existing configs (API key + graph ID) get the modern transport with no changes. `ROBOSYSTEMS_MCP_MODE=legacy` opts back into the bridge — needed only against API deployments predating the MCP transport (pre-v1.7.0) or configs relying on the client-side workspace tool names (current servers expose the equivalent subgraph tools natively)
- `ROBOSYSTEMS_MCP_URL` targets a specific endpoint (e.g. a local stack) without a graph ID; `--proxy` forces proxy mode
- README restructured: proxy mode documented as the default, legacy bridge as the fallback, Claude Desktop guidance updated

## Testing

- 10 new vitest cases (JSON relay, SSE relay incl. keepalives + multi-line data fields, 202 notifications, HTTP/network error synthesis, protocol-version echo, end-to-end stdio pipe); full suite 66/66 green with lint + format
- Live smoke tests against prod `sec` (v1.7.0): **default mode** ran the proxy (initialize handshake with per-session instructions, 13 live tools, real tool call through the pipe); **`ROBOSYSTEMS_MCP_MODE=legacy`** ran the old bridge (REST `/mcp/tools` fetch, 13 tools)

Suggest publishing as **0.4.0** to put the default-behavior change on a version boundary.