### PR TITLE
docs: Claude connects via generated connector URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ claude mcp add --transport http robosystems-sec \
 
 Local development uses the same shape against a local stack: `http://localhost:8000/v1/graphs/{graph_id}/mcp`.
 
-**Claude (claude.ai / Desktop) cannot use the remote endpoint directly yet** — its custom connectors authenticate with OAuth only and have no custom-header field, so they cannot send an API key. Claude Desktop users should run this package via `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries); in its default [proxy mode](#proxy-mode-the-default) it delivers the full remote-endpoint behavior over stdio.
+**Claude (claude.ai / Desktop)** connects with a **connector URL** instead of a header: generate one from your Connect page in the RoboSystems app and paste it into Settings → Connectors → Add custom connector. The URL carries its own graph-scoped, revocable API key, since Claude's custom connectors cannot send custom headers. Claude Desktop can alternatively run this package via `claude_desktop_config.json` (the config file accepts only stdio-shaped `command` entries); in its default [proxy mode](#proxy-mode-the-default) it delivers the same remote-endpoint behavior over stdio.
 
 ## Tools
 


### PR DESCRIPTION
## Summary

Updates the Claude paragraph now that graph-scoped connector URLs are live on the platform (robosystems v1.7.1): claude.ai / Claude Desktop paste a connector URL generated from the app's Connect page — the URL carries its own graph-scoped, revocable key. Proxy mode remains documented as the stdio alternative for Desktop and header-less clients.

**Hold merge until the v1.7.1 prod deploy + connector end-to-end verification pass.**