### PR TITLE
fix(proxy): redact credentials from the forwarded-URL stderr log

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -183,6 +183,26 @@ export function createProxy({ url, apiKey, version, output = process.stdout, fet
 }
 
 /**
+ * Strip credentials from a URL before logging it: query string (`?token=…`
+ * connector credentials), fragment, and userinfo. MCP hosts capture stderr
+ * into diagnostic logs that get shared in bug reports — the secret must
+ * never travel with them.
+ */
+export function redactUrl(url) {
+  try {
+    const parsed = new URL(url)
+    parsed.username = ''
+    parsed.password = ''
+    parsed.hash = ''
+    const hadQuery = parsed.search !== ''
+    parsed.search = ''
+    return parsed.toString() + (hadQuery ? '?<redacted>' : '')
+  } catch {
+    return '<invalid url>'
+  }
+}
+
+/**
  * Run the proxy over real stdio until the host closes stdin.
  */
 export async function runProxy({
@@ -196,7 +216,7 @@ export async function runProxy({
   const proxy = createProxy({ url, apiKey, version, output, fetchImpl })
 
   console.error(`RoboSystems MCP proxy v${version}`)
-  console.error(`Forwarding stdio <-> ${url}`)
+  console.error(`Forwarding stdio <-> ${redactUrl(url)}`)
   if (!apiKey) {
     console.error(
       'No ROBOSYSTEMS_API_KEY set — forwarding without an X-API-Key header ' +

--- a/proxy.test.js
+++ b/proxy.test.js
@@ -6,7 +6,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { Readable } from 'stream'
 import { ReadableStream } from 'stream/web'
 import { TextEncoder } from 'util'
-import { createProxy, runProxy } from './proxy.js'
+import { createProxy, runProxy, redactUrl } from './proxy.js'
 
 const URL = 'https://api.example.com/v1/graphs/kg123/mcp'
 
@@ -221,6 +221,30 @@ describe('createProxy', () => {
   })
 })
 
+describe('redactUrl', () => {
+  it('strips the query string so a ?token= credential never survives', () => {
+    const redacted = redactUrl(`${URL}?token=rfsc-super-secret`)
+    expect(redacted).not.toContain('rfsc-super-secret')
+    expect(redacted).not.toContain('token')
+    expect(redacted).toBe(`${URL}?<redacted>`)
+  })
+
+  it('strips userinfo and fragment', () => {
+    const redacted = redactUrl('https://user:pass@api.example.com/v1/graphs/kg123/mcp#frag')
+    expect(redacted).not.toContain('user')
+    expect(redacted).not.toContain('pass')
+    expect(redacted).not.toContain('frag')
+  })
+
+  it('leaves a credential-free URL readable', () => {
+    expect(redactUrl(URL)).toBe(URL)
+  })
+
+  it('never throws on garbage input', () => {
+    expect(redactUrl('not a url')).toBe('<invalid url>')
+  })
+})
+
 describe('runProxy', () => {
   it('pipes stdin lines through to the endpoint and responses back out', async () => {
     const response = { jsonrpc: '2.0', id: 1, result: { serverInfo: { name: 'robosystems' } } }
@@ -232,5 +256,31 @@ describe('runProxy', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1)
     expect(output.messages()).toEqual([response])
+  })
+
+  it('never writes a URL-carried token to stderr', async () => {
+    const token = 'rfsc-super-secret-token'
+    const fetchImpl = vi.fn().mockResolvedValue(acceptedResponse())
+    const output = makeOutput()
+    const input = Readable.from(['{"jsonrpc":"2.0","method":"notifications/initialized"}\n'])
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      await runProxy({
+        url: `${URL}?token=${token}`,
+        apiKey: undefined,
+        version: '0.0.0',
+        input,
+        output,
+        fetchImpl,
+      })
+
+      const stderr = errorSpy.mock.calls.flat().join('\n')
+      expect(stderr).not.toContain(token)
+      // The endpoint itself stays legible for debugging.
+      expect(stderr).toContain('api.example.com')
+    } finally {
+      errorSpy.mockRestore()
+    }
   })
 })


### PR DESCRIPTION
## Summary

The proxy's startup banner printed the full endpoint URL to stderr. Since the endpoint URL may carry credentials (the documented no-header configuration), the secret could land in MCP host diagnostic logs. The banner now strips the query string, fragment, and userinfo before printing, and a regression test asserts captured stderr never contains a URL-carried token.

## Changes

- `redactUrl()` helper in `proxy.js`; the `runProxy` banner logs the redacted form
- Tests: query/userinfo/fragment stripping, garbage-input safety, and an end-to-end stderr capture assertion

## Testing

- `npm run test:all` — 71 tests, format + lint clean