### PR TITLE
Align positioning, and stop the npm blurb selling the deprecated path

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@robosystems%2Fmcp.svg)](https://www.npmjs.com/package/@robosystems/mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Official MCP (Model Context Protocol) stdio bridge for connecting stdio-only AI clients to the RoboSystems Financial Knowledge Graph API. Query financial statements, explore graph structures, resolve XBRL elements, and build fact grids.
+Official MCP (Model Context Protocol) stdio bridge for connecting stdio-only AI clients to the RoboSystems financial intelligence platform. Query financial statements, explore graph structures, resolve XBRL elements, and build fact grids.
 
 > **The preferred way to connect is the hosted remote MCP endpoint — no install required.** Every RoboSystems graph serves the MCP Streamable HTTP transport directly: add `https://api.robosystems.ai/v1/graphs/{graph_id}/mcp` as a connector with your API key in the `X-API-Key` header, and Claude Code, Cursor, VS Code, or any HTTP-capable MCP client connects with zero setup. **This npx package is in maintenance mode** and exists for clients that only speak the stdio transport: by default it runs in [proxy mode](#proxy-mode-the-default), forwarding that same modern transport over stdio. See [Migrating to the remote endpoint](#migrating-to-the-remote-endpoint).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@robosystems/mcp",
   "version": "0.4.1",
-  "description": "MCP client adapter for connecting AI agents to RoboSystems Financial Knowledge Graph API endpoints with workspace support",
+  "description": "MCP stdio bridge connecting stdio-only AI clients to the RoboSystems financial intelligence platform; proxies to the hosted remote MCP endpoint by default",
   "type": "module",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Two one-line fixes, one of which is more than cosmetic.

**1. The npm description was still selling this package as the way in.** It read *"MCP client adapter for connecting AI agents to RoboSystems Financial Knowledge Graph API endpoints with workspace support"* — but the README has said since v0.4.0 that this npx package is in **maintenance mode**, and that the preferred path is the hosted remote MCP endpoint that needs no install. The npm listing is where most people meet this package, and it was pointing them at the path we deprecated. It now says what the README says.

**2. "Financial Knowledge Graph API" → "financial intelligence platform"** in the README opening — the naming the platform retired, aligned here with the repo README, the wiki, and the GitHub repo descriptions across the org.

| File | Surface it feeds |
| --- | --- |
| `README.md` | GitHub repo page |
| `package.json` | **npm package subtitle** |

The npm description reaches the registry on the next publish; the GitHub description is already live, so the two are briefly out of step until then.

No version bump and no behavior change — proxy mode remains the default. Pre-commit gate green: prettier, lint, 71 tests passed.