### PR TITLE
chore(ci): drop the stale model pin from the claude_args example

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -74,5 +74,5 @@ jobs:
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
## Summary

`.github/workflows/claude.yml` here was the only one of eleven repositories whose commented `claude_args` example pinned a model — `claude-opus-4-1-20250805`, long superseded — and the only one linking the `sdk#command-line` docs anchor instead of `cli-reference`. The file now matches the other ten exactly.

## Changes

- Removed `--model claude-opus-4-1-20250805` from the commented `claude_args` example. Removed rather than updated: the example exists to show `claude_args` and `--allowed-tools`, the model is incidental, and a model id pinned in a comment simply rots again.
- Corrected the docs URL to `cli-reference`, matching every other repository.

## Breaking Changes

None. Comment-only change inside a CI workflow; nothing executable is touched, and neither tier of the SDK contract is affected.

## Testing

Diffed the trailing block against `robosystems-python-client` — now byte-identical.

## Secondary purpose

This PR is the acceptance test for the automatic Claude review rolled out across all eleven repositories earlier today. `claude-code-action` refuses to run when the workflow file on a PR branch differs from the default branch — an anti-tampering guard — so the eleven PRs that introduced the control could not exercise it. This is the first PR opened from a branch where the workflow matches `main`, so a review comment appearing here confirms the control operates.